### PR TITLE
Add Custom Inventory Format Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,18 @@ Usage of planet-exporter:
         Darkstat target address
   -task-darkstat-enabled
         Enable darkstat collector task
+  -task-ebpf-addr string
+        Ebpf target address (default "http://localhost:9435/metrics")
+  -task-ebpf-enabled
+        Enable Ebpf collector task
   -task-interval string
         Interval between collection of expensive data into memory (default "7s")
   -task-inventory-addr string
-        Darkstat target address
+        HTTP endpoint that returns the inventory data
   -task-inventory-enabled
         Enable inventory collector task
+  -task-inventory-format string
+        Inventory format to parse the returned inventory data (default "arrayjson")
   -task-socketstat-enabled
         Enable socketstat collector task (default true)
   -version
@@ -94,7 +100,7 @@ Running with minimum collector tasks (just the socketstat)
 # planet-exporter
 ```
 
-Running with inventory and darkstat (installed separately rev >= [e7e6652](https://www.unix4lyfe.org/gitweb/darkstat/commit/e7e6652113099e33930ab0f39630bf280e38f769))
+Running with inventory and darkstat (darkstat has to be installed separately rev >= [e7e6652](https://www.unix4lyfe.org/gitweb/darkstat/commit/e7e6652113099e33930ab0f39630bf280e38f769))
 
 ```
 # planet-exporter \
@@ -102,6 +108,15 @@ Running with inventory and darkstat (installed separately rev >= [e7e6652](https
     -task-inventory-addr http://link-to-your.net/inventory_hosts.json \
     -task-darkstat-enabled \
     -task-darkstat-addr http://localhost:51666/metrics
+```
+
+Running with another inventory format
+
+```
+# planet-exporter \
+    -task-inventory-enabled \
+    -task-inventory-format "ndjson" \
+    -task-inventory-addr http://link-to-your.net/inventory_hosts.json
 ```
 
 ### Collector Tasks
@@ -112,7 +127,9 @@ Query inventory data to map IP into `hostgroup` (an identifier based on ansible 
 
 Without this task enabled, those hostgroup and domain fields will be left empty.
 
-The flag `--task-inventory-addr` should contain an http url to an array of json objects:
+The flag `--task-inventory-addr` should contain an HTTP endpoint that returns inventory data in the supported format:
+
+##### --task-inventory-format=arrayjson
 
 ```json
 [
@@ -127,6 +144,13 @@ The flag `--task-inventory-addr` should contain an http url to an array of json 
     "hostgroup": "debugapp"
   }
 ]
+```
+
+##### --task-inventory-format=ndjson
+
+```json
+{"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"}
+{"ip_address":"172.16.1.2","domain":"abc.service.consul","hostgroup":"abc"}
 ```
 
 #### Socketstat

--- a/cmd/planet-exporter/internal/internal.go
+++ b/cmd/planet-exporter/internal/internal.go
@@ -55,6 +55,7 @@ type Config struct {
 
 	TaskInventoryEnabled bool
 	TaskInventoryAddr    string // InventoryAddr url for inventory hostgroup mapping table data
+	TaskInventoryFormat  string // InventoryFormat returned by inventory address [jsonarray,ndjson]
 
 	TaskEbpfEnabled bool
 	TaskEbpfAddr    string // TaskEbpfAddr url for scraping the ebpf data
@@ -163,7 +164,7 @@ func (s Service) collect(ctx context.Context, interval time.Duration) {
 	taskebpf.InitTask(ctx, s.Config.TaskEbpfEnabled, s.Config.TaskEbpfAddr)
 
 	log.Infof("Task Inventory: %v", s.Config.TaskInventoryEnabled)
-	taskinventory.InitTask(ctx, s.Config.TaskInventoryEnabled, s.Config.TaskInventoryAddr)
+	taskinventory.InitTask(ctx, s.Config.TaskInventoryEnabled, s.Config.TaskInventoryAddr, s.Config.TaskInventoryFormat)
 
 	log.Infof("Task Socketstat: %v", s.Config.TaskSocketstatEnabled)
 	tasksocketstat.InitTask(ctx, s.Config.TaskSocketstatEnabled)

--- a/cmd/planet-exporter/main.go
+++ b/cmd/planet-exporter/main.go
@@ -53,7 +53,8 @@ func main() {
 	flag.StringVar(&config.TaskEbpfAddr, "task-ebpf-addr", "http://localhost:9435/metrics", "Ebpf target address")
 
 	flag.BoolVar(&config.TaskInventoryEnabled, "task-inventory-enabled", false, "Enable inventory collector task")
-	flag.StringVar(&config.TaskInventoryAddr, "task-inventory-addr", "", "Darkstat target address")
+	flag.StringVar(&config.TaskInventoryAddr, "task-inventory-addr", "", "HTTP endpoint that returns the inventory data")
+	flag.StringVar(&config.TaskInventoryFormat, "task-inventory-format", "arrayjson", "Inventory format to parse the returned inventory data")
 
 	flag.Parse()
 

--- a/collector/task/inventory/inventory_test.go
+++ b/collector/task/inventory/inventory_test.go
@@ -1,0 +1,113 @@
+// Copyright 2021 - williamchanrico@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inventory
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// mockInventoryResponse returns an io.ReadCloser simulating data coming from an inventory endpoint
+func mockInventoryResponse(raw string) io.ReadCloser {
+	return io.NopCloser(strings.NewReader(raw))
+}
+
+func Test_parseInventory(t *testing.T) {
+	type args struct {
+		inventoryFormat string
+		inventoryData   io.ReadCloser
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []Host
+		wantErr bool
+	}{
+		// Format: 'ndjson'
+		{
+			name: "Test single ndjson inventory entry",
+			args: args{
+				inventoryFormat: "ndjson",
+				inventoryData: mockInventoryResponse(`
+					{"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"}
+				`),
+			},
+			want: []Host{
+				{IPAddress: "10.0.1.2", Domain: "xyz.service.consul", Hostgroup: "xyz"},
+			},
+		},
+		{
+			name: "Test multiple ndjson inventory entries",
+			args: args{
+				inventoryFormat: "ndjson",
+				inventoryData: mockInventoryResponse(`
+					{"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"}
+					{"ip_address":"172.16.1.2","domain":"abc.service.consul","hostgroup":"abc"}
+				`),
+			},
+			want: []Host{
+				{IPAddress: "10.0.1.2", Domain: "xyz.service.consul", Hostgroup: "xyz"},
+				{IPAddress: "172.16.1.2", Domain: "abc.service.consul", Hostgroup: "abc"},
+			},
+		},
+
+		// Format: 'arrayjson'
+		{
+			name: "Test single arrayjson inventory entry",
+			args: args{
+				inventoryFormat: "arrayjson",
+				inventoryData: mockInventoryResponse(`
+					[
+						{"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"}
+					]
+				`),
+			},
+			want: []Host{
+				{IPAddress: "10.0.1.2", Domain: "xyz.service.consul", Hostgroup: "xyz"},
+			},
+		},
+		{
+			name: "Test multiple arrayjson inventory entries",
+			args: args{
+				inventoryFormat: "arrayjson",
+				inventoryData: mockInventoryResponse(`
+					[
+						{"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"},
+						{"ip_address":"172.16.1.2","domain":"abc.service.consul","hostgroup":"abc"}
+					]
+				`),
+			},
+			want: []Host{
+				{IPAddress: "10.0.1.2", Domain: "xyz.service.consul", Hostgroup: "xyz"},
+				{IPAddress: "172.16.1.2", Domain: "abc.service.consul", Hostgroup: "abc"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseInventory(tt.args.inventoryFormat, tt.args.inventoryData)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseInventory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseInventory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/setup/inventories-examples/task-inventory-arrayjson.json
+++ b/setup/inventories-examples/task-inventory-arrayjson.json
@@ -1,0 +1,12 @@
+[
+  {
+    "ip_address": "10.0.1.2",
+    "domain": "xyz.service.consul",
+    "hostgroup": "xyz"
+  },
+  {
+    "ip_address": "172.16.1.2",
+    "domain": "abc.service.consul",
+    "hostgroup": "abc"
+  }
+]

--- a/setup/inventories-examples/task-inventory-ndjson.json
+++ b/setup/inventories-examples/task-inventory-ndjson.json
@@ -1,0 +1,2 @@
+{"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"}
+{"ip_address":"172.16.1.2","domain":"abc.service.consul","hostgroup":"abc"}

--- a/setup/systemd/planet-exporter.service
+++ b/setup/systemd/planet-exporter.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Planet Exporter
+After=network-online.target
+
+[Service]
+User=root
+ExecStart=/usr/bin/planet-exporter \
+	-listen-address 0.0.0.0:11910 \
+	-log-level info \
+	-log-disable-colors \
+	-log-disable-timestamp \
+	-task-darkstat-enabled=true \
+	-task-darkstat-addr http://127.0.0.1:11560/metrics \
+	-task-inventory-enabled=true \
+	-task-inventory-addr https://s3-ap-southeast-1.amazonaws.com/example/inventory.json
+LimitNOFILE=8192
+CPUQuota=20%
+MemoryHigh=256M
+MemoryMax=512M
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #10 

This adds support for custom `--task-inventory-format`.
Current supported formats: `[arrayjson,ndjson]`