### PR TITLE
Add: tcptop.yaml ebpf configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Grab a pre-built binary for your OS from the [Releases](https://github.com/willi
 
 Flags:
 
-There's no required flags. It is configured with usable defaults.
+There are no required flags. It is configured with usable defaults.
 
 ```
 Usage of planet-exporter:
@@ -102,21 +102,35 @@ Running with minimum collector tasks (just the socketstat)
 
 Running with inventory and darkstat (darkstat has to be installed separately rev >= [e7e6652](https://www.unix4lyfe.org/gitweb/darkstat/commit/e7e6652113099e33930ab0f39630bf280e38f769))
 
-```
-# planet-exporter \
-    -task-inventory-enabled \
-    -task-inventory-addr http://link-to-your.net/inventory_hosts.json \
-    -task-darkstat-enabled \
-    -task-darkstat-addr http://localhost:51666/metrics
+```sh
+planet-exporter \
+  -task-inventory-enabled \
+  -task-inventory-addr http://link-to-your.net/inventory_hosts.json \
+  -task-darkstat-enabled \
+  -task-darkstat-addr http://localhost:51666/metrics
 ```
 
 Running with another inventory format
 
+```sh
+planet-exporter \
+  -task-inventory-enabled \
+  -task-inventory-format "ndjson" \
+  -task-inventory-addr http://link-to-your.net/inventory_hosts.json
 ```
-# planet-exporter \
-    -task-inventory-enabled \
-    -task-inventory-format "ndjson" \
-    -task-inventory-addr http://link-to-your.net/inventory_hosts.json
+
+Running with ebpf and custom inventory
+
+* Follow instructions on https://github.com/cloudflare/ebpf_exporter to start ebpf_exporter with [tcptop.yaml](setup/ebpf-config/tcptop.yaml) configuration.
+
+* Run planet-exporter with ebpf enabled:
+
+```sh
+planet-exporter \
+  -task-ebpf-enabled \
+  -task-inventory-enabled \
+  -task-inventory-format "ndjson" \
+  -task-inventory-addr http://link-to-your.net/inventory_hosts.json
 ```
 
 ### Collector Tasks
@@ -216,6 +230,10 @@ planet_traffic_bytes_total{direction="egress",remote_domain="debugapp.service.co
 planet_traffic_bytes_total{direction="ingress",remote_domain="xyz.service.consul",remote_hostgroup="xyz",remote_ip="10.1.2.3"} 2525
 planet_traffic_bytes_total{direction="ingress",remote_domain="debugapp.service.consul",remote_hostgroup="debugapp",remote_ip="10.2.3.4"} 1.26014316e+08
 ```
+
+#### eBPF-exporter
+
+Planet exporter can be used along with [ebpf-exporter](https://github.com/cloudflare/ebpf_exporter) to extract packet flow information directly from kernel. PE currently supports reading prometheus data with [tcptop.yaml](setup/ebpf-config/tcptop.yaml) ebpf configuration. Checkout [ebpf-exporter](https://github.com/cloudflare/ebpf_exporter) instructions to run it with [tcptop.yaml](setup/ebpf-config/tcptop.yaml).
 
 ## Exporter Cost
 

--- a/setup/ebpf-config/tcptop.yaml
+++ b/setup/ebpf-config/tcptop.yaml
@@ -1,0 +1,146 @@
+programs:
+  - name: tcptop
+    metrics:
+      counters:
+        - name: ipv4_send_bytes
+          help: tcp_top
+          table: ipv4_send_bytes
+          labels:
+            - name: pid
+              size: 4
+              decoders:
+                - name: uint
+            - name: saddr
+              size: 4
+              decoders:
+                - name: inet_ip
+            - name: daddr
+              size: 4
+              decoders:
+                - name: inet_ip
+            - name: lport
+              size: 2
+              decoders:
+                - name: uint
+            - name: dport
+              size: 2
+              decoders:
+                - name: uint
+        - name: ipv4_recv_bytes
+          help: tcp_top
+          table: ipv4_recv_bytes
+          labels:
+            - name: pid
+              size: 4
+              decoders:
+                - name: uint
+            - name: saddr
+              size: 4
+              decoders:
+                - name: inet_ip
+            - name: daddr
+              size: 4
+              decoders:
+                - name: inet_ip
+            - name: lport
+              size: 2
+              decoders:
+                - name: uint
+            - name: dport
+              size: 2
+              decoders:
+                - name: uint    
+    kprobes:
+      tcp_sendmsg: tcp_sendmsg
+      tcp_cleanup_rbuf: tcp_cleanup_rbuf
+    code: |
+      #include <linux/nsproxy.h>
+      #include <linux/mount.h>
+      #include <linux/ns_common.h>
+      #include <uapi/linux/ptrace.h>
+      #include <net/sock.h>
+      #include <bcc/proto.h>
+      struct ipv4_key_t {
+          u32 pid;
+          u32 saddr;
+          u32 daddr;
+          u16 lport;
+          u16 dport;
+      };
+      BPF_HASH(ipv4_send_bytes, struct ipv4_key_t);
+      BPF_HASH(ipv4_recv_bytes, struct ipv4_key_t);
+      struct ipv6_key_t {
+          unsigned __int128 saddr;
+          unsigned __int128 daddr;
+          u32 pid;
+          u16 lport;
+          u16 dport;
+          u64 __pad__;
+      };
+      BPF_HASH(ipv6_send_bytes, struct ipv6_key_t);
+      BPF_HASH(ipv6_recv_bytes, struct ipv6_key_t);
+
+      int tcp_sendmsg(struct pt_regs *ctx, struct sock *sk,
+          struct msghdr *msg, size_t size)
+      {
+          u32 pid = bpf_get_current_pid_tgid() >> 32;
+          u16 dport = 0, family = sk->__sk_common.skc_family;
+          
+          if (family == AF_INET) {
+              struct ipv4_key_t ipv4_key = {.pid = pid};
+              ipv4_key.saddr = sk->__sk_common.skc_rcv_saddr;
+              ipv4_key.daddr = sk->__sk_common.skc_daddr;
+              ipv4_key.lport = sk->__sk_common.skc_num;
+              dport = sk->__sk_common.skc_dport;
+              ipv4_key.dport = ntohs(dport);
+              ipv4_send_bytes.increment(ipv4_key, size);
+          } else if (family == AF_INET6) {
+              struct ipv6_key_t ipv6_key = {.pid = pid};
+              bpf_probe_read_kernel(&ipv6_key.saddr, sizeof(ipv6_key.saddr),
+                  &sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+              bpf_probe_read_kernel(&ipv6_key.daddr, sizeof(ipv6_key.daddr),
+                  &sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+              ipv6_key.lport = sk->__sk_common.skc_num;
+              dport = sk->__sk_common.skc_dport;
+              ipv6_key.dport = ntohs(dport);
+              ipv6_send_bytes.increment(ipv6_key, size);
+          }
+          // else drop
+          return 0;
+      }
+      /*
+       * tcp_recvmsg() would be obvious to trace, but is less suitable because:
+       * - we'd need to trace both entry and return, to have both sock and size
+       * - misses tcp_read_sock() traffic
+       * we'd much prefer tracepoints once they are available.
+       */
+      int tcp_cleanup_rbuf(struct pt_regs *ctx, struct sock *sk, int copied)
+      {
+          u32 pid = bpf_get_current_pid_tgid() >> 32;
+          u16 dport = 0, family = sk->__sk_common.skc_family;
+          u64 *val, zero = 0;
+          if (copied <= 0)
+              return 0;
+          
+          if (family == AF_INET) {
+              struct ipv4_key_t ipv4_key = {.pid = pid};
+              ipv4_key.saddr = sk->__sk_common.skc_rcv_saddr;
+              ipv4_key.daddr = sk->__sk_common.skc_daddr;
+              ipv4_key.lport = sk->__sk_common.skc_num;
+              dport = sk->__sk_common.skc_dport;
+              ipv4_key.dport = ntohs(dport);
+              ipv4_recv_bytes.increment(ipv4_key, copied);
+          } else if (family == AF_INET6) {
+              struct ipv6_key_t ipv6_key = {.pid = pid};
+              bpf_probe_read_kernel(&ipv6_key.saddr, sizeof(ipv6_key.saddr),
+                  &sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+              bpf_probe_read_kernel(&ipv6_key.daddr, sizeof(ipv6_key.daddr),
+                  &sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+              ipv6_key.lport = sk->__sk_common.skc_num;
+              dport = sk->__sk_common.skc_dport;
+              ipv6_key.dport = ntohs(dport);
+              ipv6_recv_bytes.increment(ipv6_key, copied);
+          }
+          // else drop
+          return 0;
+      }


### PR DESCRIPTION
* Added tcptop ebpf configuration that can be used along with PE to extract network telemetry data.
*  What data? : TCP send and receive byte size, local port and IP, destination port and ip. 
* [ebpf-exporter](https://github.com/cloudflare/ebpf_exporter) can be run with `--config.file=setup/ebpf-config/tcptop.yaml` flag.
* PE will read the prometheus endpoint of [ebpf-exporter](https://github.com/cloudflare/ebpf_exporter) and optionally enrich it with inventory data.