### PR TITLE
Add support for longest-prefix CIDR address inventory match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 NAME          := planet-exporter
 BIN_DIRECTORY := ./bin
 REVISION      := $(shell git rev-parse --short HEAD 2>/dev/null)
-VERSION       := v0.2.0-dev
+VERSION       := v0.3.0-dev
 
 ifndef REVISION
 	override REVISION = none
@@ -65,6 +65,10 @@ go-build-linux: ## Build the app for linux platforms exclude: "arm64" CGO errors
 		cd ..; \
 	done;
 	@rm -rf $(BIN_DIRECTORY)/$(APP_NAME)
+
+.PHONY: go-test
+go-test: ## Run go test
+	go test -v ./...
 
 # DOCKER TASKS
 # Build the container

--- a/README.md
+++ b/README.md
@@ -137,11 +137,12 @@ planet-exporter \
 
 #### Inventory
 
-Query inventory data to map IP into `hostgroup` (an identifier based on ansible convention) and `domain`.
+Query inventory data that will be used to map `ip_address` into `hostgroup` (an identifier based on Ansible convention) and `domain`.
+The `ip_address` may use CIDR notation (e.g. "10.1.0.0/16") and Inventory task will use the longest-prefix match.
 
-Without this task enabled, those hostgroup and domain fields will be left empty.
+Without this task enabled, those hostgroup and domain fields will be empty.
 
-The flag `--task-inventory-addr` should contain an HTTP endpoint that returns inventory data in the supported format:
+The flag `--task-inventory-addr` accepts an HTTP endpoint that returns inventory data in the supported format:
 
 ##### --task-inventory-format=arrayjson
 
@@ -156,6 +157,11 @@ The flag `--task-inventory-addr` should contain an HTTP endpoint that returns in
     "ip_address": "10.2.3.4",
     "domain": "debugapp.service.consul",
     "hostgroup": "debugapp"
+  },
+  {
+    "ip_address": "10.3.0.0/16",
+    "domain": "",
+    "hostgroup": "unknown-but-its-network-xyz"
   }
 ]
 ```
@@ -165,6 +171,7 @@ The flag `--task-inventory-addr` should contain an HTTP endpoint that returns in
 ```json
 {"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"}
 {"ip_address":"172.16.1.2","domain":"abc.service.consul","hostgroup":"abc"}
+{"ip_address":"10.3.0.0/16","domain":"","hostgroup":"unknown-but-its-network-xyz"}
 ```
 
 #### Socketstat

--- a/cmd/planet-exporter/internal/internal.go
+++ b/cmd/planet-exporter/internal/internal.go
@@ -160,7 +160,7 @@ func (s Service) collect(ctx context.Context, interval time.Duration) {
 	log.Infof("Task Darkstat: %v", s.Config.TaskDarkstatEnabled)
 	taskdarkstat.InitTask(ctx, s.Config.TaskDarkstatEnabled, s.Config.TaskDarkstatAddr)
 
-	log.Infof("Task ebpf: %v", s.Config.TaskEbpfEnabled)
+	log.Infof("Task EBPF: %v", s.Config.TaskEbpfEnabled)
 	taskebpf.InitTask(ctx, s.Config.TaskEbpfEnabled, s.Config.TaskEbpfAddr)
 
 	log.Infof("Task Inventory: %v", s.Config.TaskInventoryEnabled)

--- a/collector/task/inventory/host.go
+++ b/collector/task/inventory/host.go
@@ -1,0 +1,69 @@
+package inventory
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Host contains an inventory entry
+type Host struct {
+	Domain    string `json:"domain"`
+	Hostgroup string `json:"hostgroup"`
+	IPAddress string `json:"ip_address"`
+}
+
+// requestHosts requests a new inventory host entries from upstream inventoryAddr
+func requestHosts(ctx context.Context, httpClient *http.Client, inventoryFormat, inventoryAddr string) ([]Host, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, inventoryAddr, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	return parseHosts(inventoryFormat, response.Body)
+}
+
+// parseHosts parses inventory data as a list of Host
+func parseHosts(format string, data io.Reader) ([]Host, error) {
+	var result []Host
+
+	decoder := json.NewDecoder(data)
+	decoder.DisallowUnknownFields()
+
+	switch format {
+	case "ndjson":
+		inventoryEntry := Host{}
+		for decoder.More() {
+			err := decoder.Decode(&inventoryEntry)
+			if err != nil {
+				log.Errorf("Skip an inventory host entry due to parser error: %v", err)
+				continue
+			}
+			result = append(result, inventoryEntry)
+		}
+
+	case "arrayjson":
+		err := decoder.Decode(&result)
+		if err != nil {
+			return nil, err
+		}
+
+		// We expect a single JSON array object here. Clear unexpected data that's left in the io.ReadCloser
+		if decoder.More() {
+			bytesCopied, _ := io.Copy(ioutil.Discard, data)
+			log.Warnf("Unexpected remaining data (%v Bytes) while parsing inventory hosts", bytesCopied)
+		}
+	}
+	log.Debugf("Parsed %v inventory hosts", len(result))
+
+	return result, nil
+}

--- a/collector/task/inventory/inventory.go
+++ b/collector/task/inventory/inventory.go
@@ -158,6 +158,7 @@ func (i Inventory) GetHost(address string) (Host, bool) {
 			matchedHost = ipNetHost.host
 		}
 	}
+	// There is a match when it's greater than 0 (even 0.0.0.0/0)
 	if matchedPrefixLen >= 0 {
 		return matchedHost, true
 	}

--- a/collector/task/inventory/inventory.go
+++ b/collector/task/inventory/inventory.go
@@ -154,7 +154,7 @@ func (i Inventory) GetHost(address string) (Host, bool) {
 	for _, ipNetHost := range i.networkToHosts {
 		currPrefixLen, _ := ipNetHost.network.Mask.Size()
 		if ipNetHost.network.Contains(targetIP) && currPrefixLen > matchedPrefixLen {
-			matchedPrefixLen, _ = ipNetHost.network.Mask.Size()
+			matchedPrefixLen = currPrefixLen
 			matchedHost = ipNetHost.host
 		}
 	}

--- a/collector/task/socketstat/socketstat.go
+++ b/collector/task/socketstat/socketstat.go
@@ -118,27 +118,21 @@ func Collect(ctx context.Context) error {
 	var upstreams []Connections
 	var downstreams []Connections
 	for _, peerConn := range peers {
-		inventoryHosts["127.0.0.1"] = inventory.Host{
-			Domain:    "localhost",
-			Hostgroup: "localhost",
-			IPAddress: "127.0.0.1",
-		}
-
 		if peerConn.LocalIP == "127.0.0.1" {
 			peerConn.LocalIP = defaultLocalAddr.String()
 		}
 
 		var localAddr, localHostgroup, remoteAddr, remoteHostgroup string
-		if localHostInfo, ok := inventoryHosts[peerConn.LocalIP]; ok {
-			localAddr = localHostInfo.Domain
-			localHostgroup = localHostInfo.Hostgroup
+		if localInventoryHost, ok := inventoryHosts.GetHost(peerConn.LocalIP); ok {
+			localAddr = localInventoryHost.Domain
+			localHostgroup = localInventoryHost.Hostgroup
 		}
 		if localAddr == "" {
 			localAddr = peerConn.LocalIP
 		}
-		if remoteHostInfo, ok := inventoryHosts[peerConn.RemoteIP]; ok {
-			remoteAddr = remoteHostInfo.Domain
-			remoteHostgroup = remoteHostInfo.Hostgroup
+		if remoteInventoryHost, ok := inventoryHosts.GetHost(peerConn.RemoteIP); ok {
+			remoteAddr = remoteInventoryHost.Domain
+			remoteHostgroup = remoteInventoryHost.Hostgroup
 
 		}
 		if remoteAddr == "" {

--- a/setup/inventories/task-inventory-arrayjson.json
+++ b/setup/inventories/task-inventory-arrayjson.json
@@ -8,5 +8,10 @@
     "ip_address": "172.16.1.2",
     "domain": "abc.service.consul",
     "hostgroup": "abc"
+  },
+  {
+    "ip_address": "10.3.0.0/16",
+    "domain": "",
+    "hostgroup": "unknown-but-its-network-xyz"
   }
 ]

--- a/setup/inventories/task-inventory-ndjson.json
+++ b/setup/inventories/task-inventory-ndjson.json
@@ -1,2 +1,3 @@
 {"ip_address":"10.0.1.2","domain":"xyz.service.consul","hostgroup":"xyz"}
 {"ip_address":"172.16.1.2","domain":"abc.service.consul","hostgroup":"abc"}
+{"ip_address":"10.3.0.0/16","domain":"","hostgroup":"unknown-but-its-network-xyz"}


### PR DESCRIPTION
* Remodel Inventory Collector Task map into a struct
This abstracts away the underlying inventory data structures that store the
actual mapping between addresses to Host.

* Add CIDR notation address support for inventory mapping to Host
This will try longest-prefix CIDR network match when single IP doesn't exists.